### PR TITLE
Disabling zeroconf from glocaltokens

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Manage labels
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - dev
       - master

--- a/custom_components/ha-google-home/api.py
+++ b/custom_components/ha-google-home/api.py
@@ -43,10 +43,10 @@ class GlocaltokensApiClient:
             raise InvalidMasterToken
         return master_token
 
-    def get_google_devices_json(self):
+    def get_google_devices(self):
         """Get google device authentication tokens.
         Note this method will fetch necessary access tokens if missing"""
-        return self._client.get_google_devices_json()
+        return self._client.get_google_devices(disable_discovery=True)
 
     def get_android_id(self):
         """Generate random android_id"""

--- a/custom_components/ha-google-home/manifest.json
+++ b/custom_components/ha-google-home/manifest.json
@@ -6,6 +6,6 @@
   "domain": "ha-google-home",
   "issue_tracker": "https://github.com/leikoilja/ha-google-home/issues",
   "name": "HA-Google-Home",
-  "requirements": ["glocaltokens==0.2.0"],
+  "requirements": ["glocaltokens==0.2.1"],
   "version": "0.0.2"
 }


### PR DESCRIPTION
- Fetching list of devices, not json.
- Disabling zeroconf discovery from glocaltokens

Note: it depends on `master` branch of `glocaltokens`, which is not yet released. `disable_discovery` is only coming in a next release